### PR TITLE
:wrench: chore: ラベルの指定を削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,3 @@ updates:
     open-pull-requests-limit: 5
     allow:
       - dependency-type: 'all'
-    labels:
-      - 'dependencies'
-      - 'dependabot'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Dependabotの設定を更新し、コミットメッセージのプレフィックスを指定。
	- 同時に開くことができるプルリクエストの最大数を5に設定。
	- 不要な`labels`セクションを削除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->